### PR TITLE
Fix Issue #4

### DIFF
--- a/MouseKeyHook/KeyPressEventArgsExt.cs
+++ b/MouseKeyHook/KeyPressEventArgsExt.cs
@@ -74,9 +74,8 @@ namespace Gma.System.MouseKeyHook
 
             char[] chars;
 
-            var isOk = 
-                KeyboardNativeMethods.TryGetCharFromKeyboardState(virtualKeyCode, scanCode, fuState, out chars);
-            if (!isOk) yield break;
+            KeyboardNativeMethods.TryGetCharFromKeyboardState(virtualKeyCode, scanCode, fuState, out chars);
+            if (chars == null) yield break;
             foreach (var ch in chars)
             {
                 yield return new KeyPressEventArgsExt(ch);
@@ -108,9 +107,8 @@ namespace Gma.System.MouseKeyHook
             else
             {
                 char[] chars;
-                var isOk =
-                    KeyboardNativeMethods.TryGetCharFromKeyboardState(virtualKeyCode, scanCode, fuState, out chars);
-                if (!isOk) yield break;
+                KeyboardNativeMethods.TryGetCharFromKeyboardState(virtualKeyCode, scanCode, fuState, out chars);
+                if (chars == null) yield break;
                 foreach (var current in chars)
                 {
                     yield return new KeyPressEventArgsExt(current, keyboardHookStruct.Time);


### PR DESCRIPTION
Fixed issue with dead-keys

Credits: https://gist.github.com/Ciantic/471698

Changed the way characters were capitalized by setting the key states
for the ToUnicodeEx buffer.  This retrieves the correct unicode value
given the state of the caps lock and shift keys