### PR TITLE
Dead-key fix

### DIFF
--- a/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
+++ b/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
@@ -115,7 +115,11 @@ namespace Gma.System.MouseKeyHook.WinApi
             {
                 StringBuilder sbTemp = new StringBuilder(5);
                 ToUnicodeEx(lastVirtualKeyCode, lastScanCode, lastKeyState, sbTemp, sbTemp.Capacity, 0, dwhkl);
-                lastVirtualKeyCode = 0;
+
+                if (chars != null)
+                {
+                    lastVirtualKeyCode = 0;
+                }
 
                 return true;
             }


### PR DESCRIPTION
Fixed case of pressing dead-key to accent characters followed by Shift +
character to present an uppercase character