### PR TITLE
Dead-key fix #2

### DIFF
--- a/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
+++ b/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
@@ -128,8 +128,6 @@ namespace Gma.System.MouseKeyHook.WinApi
             lastVirtualKeyCode = virtualKeyCode;
             lastIsDead = isDead;
             lastKeyState = (byte[]) currentKeyboardState.Clone();
-
-            return;
         }
 
 

--- a/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
+++ b/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
@@ -108,7 +108,8 @@ namespace Gma.System.MouseKeyHook.WinApi
 
                 // Two or more (only two of them is relevant)
                 default:
-                    chars = new[] { pwszBuff[0], pwszBuff[1] };
+                    if (pwszBuff.Length > 1) chars = new[] { pwszBuff[0], pwszBuff[1] };
+                    else chars = null;
                     break;
             }
 

--- a/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
+++ b/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
@@ -102,7 +102,8 @@ namespace Gma.System.MouseKeyHook.WinApi
                     break;
 
                 case 1:
-                    chars = new[] { pwszBuff[0] };
+                    if (pwszBuff.Length > 0) chars = new[] { pwszBuff[0] };
+                    else chars = null;
                     break;
 
                 // Two or more (only two of them is relevant)

--- a/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
+++ b/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
@@ -113,10 +113,9 @@ namespace Gma.System.MouseKeyHook.WinApi
 
             if (lastVirtualKeyCode != 0 && lastIsDead)
             {
-                StringBuilder sbTemp = new StringBuilder(5);
-
                 if (chars != null)
                 {
+                    StringBuilder sbTemp = new StringBuilder(5);
                     ToUnicodeEx(lastVirtualKeyCode, lastScanCode, lastKeyState, sbTemp, sbTemp.Capacity, 0, dwhkl);
                     lastIsDead = false;
                     lastVirtualKeyCode = 0;

--- a/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
+++ b/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
@@ -44,11 +44,11 @@ namespace Gma.System.MouseKeyHook.WinApi
         /// <param name="fuState"></param>
         /// <param name="chars"></param>
         /// <returns></returns>
-        internal static bool TryGetCharFromKeyboardState(int virtualKeyCode, int fuState, out char[] chars)
+        internal static void TryGetCharFromKeyboardState(int virtualKeyCode, int fuState, out char[] chars)
         {
             var dwhkl = GetActiveKeyboard();
             int scanCode = MapVirtualKeyEx(virtualKeyCode, (int) MapType.MAPVK_VK_TO_VSC, dwhkl);
-            return TryGetCharFromKeyboardState(virtualKeyCode, scanCode, fuState, dwhkl, out chars);
+            TryGetCharFromKeyboardState(virtualKeyCode, scanCode, fuState, dwhkl, out chars);
         }
 
         /// <summary>
@@ -59,10 +59,10 @@ namespace Gma.System.MouseKeyHook.WinApi
         /// <param name="fuState"></param>
         /// <param name="chars"></param>
         /// <returns></returns>
-        internal static bool TryGetCharFromKeyboardState(int virtualKeyCode, int scanCode, int fuState, out char[] chars)
+        internal static void TryGetCharFromKeyboardState(int virtualKeyCode, int scanCode, int fuState, out char[] chars)
         {
             var dwhkl = GetActiveKeyboard(); //get the active keyboard layout
-            return TryGetCharFromKeyboardState(virtualKeyCode, scanCode, fuState, dwhkl, out chars);
+            TryGetCharFromKeyboardState(virtualKeyCode, scanCode, fuState, dwhkl, out chars);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Gma.System.MouseKeyHook.WinApi
         /// <param name="dwhkl"></param>
         /// <param name="chars"></param>
         /// <returns></returns>
-        internal static bool TryGetCharFromKeyboardState(int virtualKeyCode, int scanCode, int fuState, IntPtr dwhkl, out char[] chars)
+        internal static void TryGetCharFromKeyboardState(int virtualKeyCode, int scanCode, int fuState, IntPtr dwhkl, out char[] chars)
         {
             StringBuilder pwszBuff = new StringBuilder(64);
             KeyboardState keyboardState = KeyboardState.GetCurrent();
@@ -114,14 +114,15 @@ namespace Gma.System.MouseKeyHook.WinApi
             if (lastVirtualKeyCode != 0 && lastIsDead)
             {
                 StringBuilder sbTemp = new StringBuilder(5);
-                ToUnicodeEx(lastVirtualKeyCode, lastScanCode, lastKeyState, sbTemp, sbTemp.Capacity, 0, dwhkl);
 
                 if (chars != null)
                 {
+                    ToUnicodeEx(lastVirtualKeyCode, lastScanCode, lastKeyState, sbTemp, sbTemp.Capacity, 0, dwhkl);
+                    lastIsDead = false;
                     lastVirtualKeyCode = 0;
                 }
 
-                return true;
+                return;
             }
 
             lastScanCode = scanCode;
@@ -129,7 +130,7 @@ namespace Gma.System.MouseKeyHook.WinApi
             lastIsDead = isDead;
             lastKeyState = (byte[]) currentKeyboardState.Clone();
 
-            return true;
+            return;
         }
 
 

--- a/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
+++ b/MouseKeyHook/WinApi/KeyboardNativeMethods.cs
@@ -109,7 +109,7 @@ namespace Gma.System.MouseKeyHook.WinApi
                 // Two or more (only two of them is relevant)
                 default:
                     if (pwszBuff.Length > 1) chars = new[] { pwszBuff[0], pwszBuff[1] };
-                    else chars = null;
+                    else chars = new[] { pwszBuff[0] };
                     break;
             }
 


### PR DESCRIPTION
Previously I thought I had fixed this, the system was posting the
correct messages, however we weren't receiving the correct data.  This
fix ensures that the key press after the accent dead-key in this tested
case '^' followed by a shift key press to capitalize the character, is
receiving the correct values to display in our application.

Also refactored some redundancy