### PR TITLE
Fixed problem of type a tilde ("~")  in swedish keyboad.  

### DIFF
--- a/MouseKeyHook/KeyPressEventArgsExt.cs
+++ b/MouseKeyHook/KeyPressEventArgsExt.cs
@@ -87,7 +87,7 @@ namespace Gma.System.MouseKeyHook
             var wParam = data.WParam;
             var lParam = data.LParam;
 
-            if ((int) wParam != Messages.WM_KEYDOWN)
+            if ((int) wParam != Messages.WM_KEYDOWN && (int)wParam != Messages.WM_SYSKEYDOWN)
             {
                 yield break;
             }


### PR DESCRIPTION
**Issue description:**

If we set "Swedish (Sweden)” as input language, we can normally get a tilde by pressing "Right Alt Key + ]" (i.e., "0xA5 + ]" or "VK_RMENU + ]") followed by anything else. When using this library to listen to keyboard and mouse input we cannot.

Note that if you press the "Right Alt Key + ]" two times in a row, it will give us two tilde characters. This is working correctly.

**To reproduce:**

1. Ensure you are using a US English keyboard (i.e., standard US keyboard)
1. Set the language on the Language Bar to Swedish
1. Ensure that the demo application included in this library is running.
1. Type "Right Alt Key + ]" (hold down alt, then press ]).
1. Type space.
1. Only a space is shown... a ~ should have been produced.