### PR TITLE
Fix not firing MouseUpExt event after doubleclick

### DIFF
--- a/MouseKeyHook/Implementation/MouseListener.cs
+++ b/MouseKeyHook/Implementation/MouseListener.cs
@@ -135,6 +135,7 @@ namespace Gma.System.MouseKeyHook.Implementation
             {
                 e = e.ToDoubleClickEventArgs();
                 OnUp(e);
+                OnUpExt(e);
                 OnDoubleClick(e);
                 m_DoubleDown.Remove(e.Button);
             }


### PR DESCRIPTION
btw, not sure that OnClick/OnDoubleClick should be after OnUp/OnUpExt and
```
                if (e.Handled)
                {
                    return;
                }
```
before `m_SingleDown.Remove(e.Button);`