### PR TITLE
Update FromString to allow for raw characters

### DIFF
--- a/MouseKeyHook.Rx/MouseKeyHook.Rx.csproj
+++ b/MouseKeyHook.Rx/MouseKeyHook.Rx.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/MouseKeyHook/Combination.cs
+++ b/MouseKeyHook/Combination.cs
@@ -110,11 +110,7 @@ namespace Gma.System.MouseKeyHook
         /// </summary>
         public static Combination FromString(string trigger)
         {
-            var parts = trigger
-                .Split('+')
-                .Select(p => Enum.Parse(typeof(Keys), p))
-                .Cast<Keys>();
-            var stack = new Stack<Keys>(parts);
+            var stack = Shared.FromString(trigger);
             var triggerKey = stack.Pop();
             return new Combination(triggerKey, stack);
         }

--- a/MouseKeyHook/Implementation/Chord.cs
+++ b/MouseKeyHook/Implementation/Chord.cs
@@ -41,11 +41,7 @@ namespace Gma.System.MouseKeyHook.Implementation
 
         public static Chord FromString(string chord)
         {
-            var parts = chord
-                .Split('+')
-                .Select(p => Enum.Parse(typeof(Keys), p))
-                .Cast<Keys>();
-            var stack = new Stack<Keys>(parts);
+            var stack = Shared.FromString(chord);
             return new Chord(stack);
         }
 

--- a/MouseKeyHook/MouseKeyHook.csproj
+++ b/MouseKeyHook/MouseKeyHook.csproj
@@ -73,7 +73,7 @@
     <ErrorReport>prompt</ErrorReport>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <RunCodeAnalysis>true</RunCodeAnalysis>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release\</OutputPath>
@@ -97,6 +97,7 @@
     <DebugType>none</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>7.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -211,6 +212,7 @@
     <Compile Include="Sequence.cs" />
     <Compile Include="SequenceBase.cs" />
     <Compile Include="Combination.cs" />
+    <Compile Include="Shared.cs" />
     <Compile Include="WinApi\AppMouseStruct.cs" />
     <Compile Include="WinApi\CallbackData.cs" />
     <Compile Include="WinApi\HookHelper.cs" />

--- a/MouseKeyHook/Shared.cs
+++ b/MouseKeyHook/Shared.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using static Gma.System.MouseKeyHook.WinApi.KeyboardNativeMethods;
+
+namespace Gma.System.MouseKeyHook
+{
+    internal static class Shared
+    {        
+        public static Stack<Keys> FromString(string str)
+        {
+            IEnumerable<Keys> keys =
+                str
+                    .Split('+')
+                    .Select(p =>
+                    {
+                        if (p.Length == 1 && TryGetKeyFromChar(p.First(), out Keys key))
+                            return key;
+                        else
+                            return (Keys)Enum.Parse(typeof(Keys), p, false);
+
+                    });
+            return new Stack<Keys>(keys);
+        }
+    }
+}

--- a/MouseKeyHook/Shared.cs
+++ b/MouseKeyHook/Shared.cs
@@ -18,7 +18,7 @@ namespace Gma.System.MouseKeyHook
                         if (p.Length == 1 && TryGetKeyFromChar(p.First(), out Keys key))
                             return key;
                         else
-                            return (Keys)Enum.Parse(typeof(Keys), p, false);
+                            return (Keys)Enum.Parse(typeof(Keys), p, true);
 
                     });
             return new Stack<Keys>(keys);

--- a/examples/ConsoleHook.Rx/ConsoleHook.Rx.csproj
+++ b/examples/ConsoleHook.Rx/ConsoleHook.Rx.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -30,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/examples/ConsoleHook/ConsoleHook.csproj
+++ b/examples/ConsoleHook/ConsoleHook.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -30,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/examples/ConsoleHook/DetectCombinations.cs
+++ b/examples/ConsoleHook/DetectCombinations.cs
@@ -18,11 +18,13 @@ namespace ConsoleHook
             {
                 //Specify which key combinations to detect and action - what to do if detected.
                 //You can create a key combinations directly from string or ...
+                {Combination.FromString(@"A+\"), () => Console.WriteLine(":-*") },
                 {Combination.FromString("A+B+C"), () => Console.WriteLine(":-)")},
-                //... or alternatively you can use builder methods
-                {Combination.TriggeredBy(Keys.F).With(Keys.E).With(Keys.D), () => Console.WriteLine(":-D")},
                 {Combination.FromString("Alt+A"), () => Console.WriteLine(":-P")},
                 {Combination.FromString("Control+Shift+Z"), () => Console.WriteLine(":-/")},
+                //... or alternatively you can use builder methods
+                {Combination.TriggeredBy(Keys.F).With(Keys.E).With(Keys.D), () => Console.WriteLine(":-D")},
+
                 {Combination.FromString("Escape"), quit}
             };
 

--- a/examples/ConsoleHook/DetectSequences.cs
+++ b/examples/ConsoleHook/DetectSequences.cs
@@ -15,6 +15,7 @@ namespace ConsoleHook
         {
             var map = new Dictionary<Sequence, Action>
             {
+                {Sequence.FromString("Control+Z,`"), Console.WriteLine},
                 {Sequence.FromString("Control+Z,B"), Console.WriteLine},
                 {Sequence.FromString("Control+Z,Z"), Console.WriteLine},
                 {Sequence.FromString("Escape,Escape,Escape"), quit}

--- a/examples/FormsExample/FormsExample.csproj
+++ b/examples/FormsExample/FormsExample.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -30,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
This pull request allows key combinations / sequences to be defined using raw characters, not just C# Enum names. An example of the change:

``Combination.FromString(@"A+Oemtilde")`` can now be ``Combination.FromString(@"A+`")``

In addition, the conversions have been made case-insensitive, so
``Combination.FromString(@"A+Oemtilde")`` can now be ``Combination.FromString(@"a+OeMtIlDe")``

Currently, something like `Combination.FromString(@"A++")` is not supported, however. The `+` will still need to be `OemPlus`.

Finally, the C# version has been updated to be C# 7.0.

Please let me know if you have any questions / suggestions.