### PR TITLE
Sequence control control fix

### DIFF
--- a/MouseKeyHook/KeyCombinationExtensions.cs
+++ b/MouseKeyHook/KeyCombinationExtensions.cs
@@ -37,7 +37,7 @@ namespace Gma.System.MouseKeyHook
             source.KeyDown += (sender, e) =>
             {
                 KeyValuePair<Combination, Action>[] element;
-                var found = watchlists.TryGetValue(e.KeyCode, out element);
+                var found = watchlists.TryGetValue(e.KeyCode.Normalize(), out element);
                 if (!found)
                 {
                     reset?.Invoke();


### PR DESCRIPTION
Fixed missing Normalize() in KeyCombinationExtensions class causing combinations & sequences to not work when trigger key was Shift or Control.