### PR TITLE
Examples adapted to .net core3.1 (Fixes #132)

### DIFF
--- a/MouseKeyHook.Rx/MouseKeyHook.Rx.csproj
+++ b/MouseKeyHook.Rx/MouseKeyHook.Rx.csproj
@@ -18,12 +18,13 @@
     <Description>This is an extension to the MouseKeyHook library which allows you to observe keyboard and mouse venets in reactive manner using Rx.Net (System.Reactive) extensions.</Description>
     <Authors>George Mamaladze</Authors>
     <PackageId>MouseKeyHook.Rx</PackageId>
-    <PackageIconUrl>https://raw.githubusercontent.com/gmamaladze/globalmousekeyhook/master/mouse-keyboard-hook-logo64x64.png</PackageIconUrl>
+    <PackageIconUrl></PackageIconUrl>
     <PackageProjectUrl>https://github.com/gmamaladze/globalmousekeyhook</PackageProjectUrl>
     <PackageTags>keyboard mouse hook reactive Rx event global spy</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/gmamaladze/globalmousekeyhook</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PackageIcon>mouse-keyboard-hook-logo64x64.png</PackageIcon>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,6 +46,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\mouse-keyboard-hook-logo64x64.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
     <None Include="MouseKeyHook.Rx.nuspec" />
   </ItemGroup>
   <ItemGroup>

--- a/MouseKeyHook/MouseKeyHook.csproj
+++ b/MouseKeyHook/MouseKeyHook.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
     <ProductVersion>9.0.21022</ProductVersion>
@@ -29,12 +29,13 @@
     </Description>
     <Copyright>(c) George Mamaladze 2000-2020</Copyright>
     <PackageId>MouseKeyHook</PackageId>
-    <PackageIconUrl>https://raw.githubusercontent.com/gmamaladze/globalmousekeyhook/master/mouse-keyboard-hook-logo64x64.png</PackageIconUrl>
+    <PackageIconUrl></PackageIconUrl>
     <PackageProjectUrl>https://github.com/gmamaladze/globalmousekeyhook</PackageProjectUrl>
     <PackageTags>keyboard mouse hook event global spy</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/gmamaladze/globalmousekeyhook</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PackageIcon>mouse-keyboard-hook-logo64x64.png</PackageIcon>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
@@ -67,6 +68,10 @@
     <DebugType>none</DebugType>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="..\mouse-keyboard-hook-logo64x64.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
     <None Include="MouseKeyHook.nuspec" />
   </ItemGroup>
 </Project>

--- a/examples/ConsoleHook.Rx/ConsoleHook.Rx.csproj
+++ b/examples/ConsoleHook.Rx/ConsoleHook.Rx.csproj
@@ -3,7 +3,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{F9B78F1A-F065-4BB4-A15B-393DFFE8DB0B}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>ConsoleHook.Rx</RootNamespace>

--- a/examples/ConsoleHook.Rx/DetectCombinations.cs
+++ b/examples/ConsoleHook.Rx/DetectCombinations.cs
@@ -30,8 +30,16 @@ namespace ConsoleHook.Rx
                 .Matching(triggers)
                 .ForEachAsync(trigger =>
                 {
-                    if (trigger == quitTrigger) quit.Set();
-                    Console.WriteLine(trigger);
+                    if (trigger == quitTrigger)
+                    {
+                        Console.WriteLine("Quit Trigger found. App should stop after {0} ... ", trigger);
+                        quit.Set();
+                        Console.Write("... AutoReset was Set, but App is still running.");
+                    }
+                    else
+                    {
+                        Console.WriteLine(trigger);
+                    }
                 });
 
             Console.WriteLine("Press Control+Q to quit.");

--- a/examples/ConsoleHook.Rx/Properties/launchSettings.json
+++ b/examples/ConsoleHook.Rx/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "ConsoleHook.Rx": {
+      "commandName": "Executable",
+      "executablePath": "dotnet",
+      "commandLineArgs": "ConsoleHook.Rx.dll"
+    }
+  }
+}

--- a/examples/ConsoleHook/ConsoleHook.csproj
+++ b/examples/ConsoleHook/ConsoleHook.csproj
@@ -3,12 +3,13 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{490FBC6C-B347-4C33-B8EF-5C67C7C4C884}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>ConsoleHook</RootNamespace>
     <AssemblyName>ConsoleHook</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <StartupObject></StartupObject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/examples/ConsoleHook/DetectSequences.cs
+++ b/examples/ConsoleHook/DetectSequences.cs
@@ -15,8 +15,8 @@ namespace ConsoleHook
         {
             var map = new Dictionary<Sequence, Action>
             {
-                {Sequence.FromString("Control+Z,B"), Console.WriteLine},
-                {Sequence.FromString("Control+Z,Z"), Console.WriteLine},
+                {Sequence.FromString("Control+Z,B"), () => Console.WriteLine("CTRL-Z followed by 'B'")},
+                {Sequence.FromString("Control+Z,Z"), () => Console.WriteLine("CTRL-Z followed by 'Z'")},
                 {Sequence.FromString("Escape,Escape,Escape"), quit}
             };
 

--- a/examples/ConsoleHook/Program.cs
+++ b/examples/ConsoleHook/Program.cs
@@ -40,8 +40,7 @@ namespace ConsoleHook
 
             Application.Run(new ApplicationContext());
         }
-
-
+       
         private static void Exit(Action quit)
         {
             Application.Exit();

--- a/examples/ConsoleHook/Properties/launchSettings.json
+++ b/examples/ConsoleHook/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "ConsoleHook": {
+      "commandName": "Executable",
+      "executablePath": "dotnet",
+      "commandLineArgs": "ConsoleHook.dll",
+      "nativeDebugging": false
+    }
+  }
+}

--- a/examples/FormsExample/Main.cs
+++ b/examples/FormsExample/Main.cs
@@ -114,12 +114,12 @@ namespace Demo
 
         private void OnKeyUp(object sender, KeyEventArgs e)
         {
-            Log(string.Format("KeyUp  \t\t {0}\n", e.KeyCode));
+            Log(string.Format("KeyUp  \t\t\t {0}\n", e.KeyCode));
         }
 
         private void HookManager_KeyPress(object sender, KeyPressEventArgs e)
         {
-            Log(string.Format("KeyPress \t\t {0}\n", e.KeyChar));
+            Log(string.Format("KeyPress \t\t\t {0}\n", e.KeyChar));
         }
 
         private void HookManager_MouseMove(object sender, MouseEventArgs e)
@@ -173,6 +173,7 @@ namespace Demo
         {
             if (IsDisposed) return;
             textBoxLog.AppendText(text);
+            textBoxLog.AppendText(Environment.NewLine);
             textBoxLog.ScrollToCaret();
         }
 


### PR DESCRIPTION
Fixes #132 
_Change in ConsoleHook and ConsoleHook.rx Projects:_
The ConsoleHook projects have thrown an Invalid Operation exception on Console.ReadKey when they were started in the IDE (Debugger). This behaviour is solved by starting the 'dotnet' app with the 'consoleHook.dll' as parameter instead of directly calling the project.

_Change in FormsExample project:_
The TextBox control in .net core Forms have a different behaviour on handling the '\n' code. To get a readable output in the log view, an `Environment.NewLine` was added after each log entry.