### PR TITLE
Update MouseListener.cs

### DIFF
--- a/MouseKeyHook/Implementation/MouseListener.cs
+++ b/MouseKeyHook/Implementation/MouseListener.cs
@@ -23,12 +23,12 @@ namespace Gma.System.MouseKeyHook.Implementation
 
         public static int GetXDragThreshold()
         {
-            return GetSystemMetrics(SM_CXDRAG);
+            return GetSystemMetrics(SM_CXDRAG) / 2 + 1;
         }
 
         public static int GetYDragThreshold()
         {
-            return GetSystemMetrics(SM_CYDRAG);
+            return GetSystemMetrics(SM_CYDRAG) / 2 + 1;
         }
     }
 
@@ -172,8 +172,9 @@ namespace Gma.System.MouseKeyHook.Implementation
 
                 if (m_IsDragging)
                 {
-                    OnDragStarted(e);
-                    OnDragStartedExt(e);
+                    var dragArgs = new MouseEventExtArgs(e.Button, e.Clicks, m_DragStartPosition, e.Delta, e.Timestamp, e.IsMouseButtonDown, e.IsMouseButtonUp);
+                    OnDragStarted(dragArgs);
+                    OnDragStartedExt(dragArgs);
                 }
             }
         }


### PR DESCRIPTION
The MouseDragStarted event should report the starting point of the drag operation (the point of mouse button down), not the point where the drag operation was detected.