### PR TITLE
Update GlobalMouseListener.cs

### DIFF
--- a/MouseKeyHook/Implementation/GlobalMouseListener.cs
+++ b/MouseKeyHook/Implementation/GlobalMouseListener.cs
@@ -24,6 +24,8 @@ namespace Gma.System.MouseKeyHook.Implementation
         {
             if (IsDoubleClick(e))
                 e = e.ToDoubleClickEventArgs();
+            else
+                StartDoubleClickWaiting(e);
             base.ProcessDown(ref e);
         }
 
@@ -32,9 +34,6 @@ namespace Gma.System.MouseKeyHook.Implementation
             base.ProcessUp(ref e);
             if (e.Clicks == 2)
                 StopDoubleClickWaiting();
-
-            if (e.Clicks == 1)
-                StartDoubleClickWaiting(e);
         }
 
         private void StartDoubleClickWaiting(MouseEventExtArgs e)


### PR DESCRIPTION
Measure the double click time from the first down to the second down, not from the first up to the second down.
The Microsoft documentation is not clear, but if you try this with the old code, you see that it is correct:
Push left button down and hold it for a few seconds, then quickly do up, down and up again. That's detected by the old code as double click, but Windows does not consider it as double click.
