### PR TITLE
Patch 5

### DIFF
--- a/MouseKeyHook/Implementation/GlobalMouseListener.cs
+++ b/MouseKeyHook/Implementation/GlobalMouseListener.cs
@@ -48,7 +48,7 @@ namespace Gma.System.MouseKeyHook.Implementation
         {
             m_PreviousClicked = MouseButtons.None;
             m_PreviousClickedTime = 0;
-            m_PreviousClickedPosition = new Point(0, 0);
+            m_PreviousClickedPosition = m_UninitialisedPoint;
         }
 
         private bool IsDoubleClick(MouseEventExtArgs e)

--- a/MouseKeyHook/Implementation/MouseListener.cs
+++ b/MouseKeyHook/Implementation/MouseListener.cs
@@ -36,7 +36,7 @@ namespace Gma.System.MouseKeyHook.Implementation
     {
         private readonly ButtonSet m_DoubleDown;
         private readonly ButtonSet m_SingleDown;
-        private readonly Point m_UninitialisedPoint = new Point(-1, -1);
+        protected readonly Point m_UninitialisedPoint = new Point(-99999, -99999);
         private readonly int m_xDragThreshold;
         private readonly int m_yDragThreshold;
         private Point m_DragStartPosition;


### PR DESCRIPTION
On multi-monitor systems, if a monitor is left and/or top of the primary monitor, it has negative screen coordinates.
Therefore using (-1,-1) as "uninitialized" screen coordinates is not a good idea.
So I changed it to coordinates which are clearly outside of any current and near-future monitors: (-99999,-99999).