### PR TITLE
Added option to detect if mouse and keyboard events are injected and not real events from the keyboard and mouse

### DIFF
--- a/MouseKeyHook.Rx/MouseKeyHook.Rx.csproj
+++ b/MouseKeyHook.Rx/MouseKeyHook.Rx.csproj
@@ -4,7 +4,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{9754749C-1EEA-4468-8C32-B5BAC3235F54}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net7.0-windows;net6.0-windows;net472;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net7.0-windows;net6.0-windows;net472;net48</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MouseKeyHook.Rx</RootNamespace>

--- a/MouseKeyHook/IKeyboardEvents.cs
+++ b/MouseKeyHook/IKeyboardEvents.cs
@@ -18,6 +18,11 @@ namespace Gma.System.MouseKeyHook
         event KeyEventHandler KeyDown;
 
         /// <summary>
+        ///     Occurs when a key is pressed. This includes additional event data such as if the event was injected.
+        /// </summary>
+        event EventHandler<KeyEventArgsExt> KeyDownExt;
+
+        /// <summary>
         ///     Occurs when a key is pressed.
         /// </summary>
         /// <remarks>
@@ -46,5 +51,10 @@ namespace Gma.System.MouseKeyHook
         ///     Occurs when a key is released.
         /// </summary>
         event KeyEventHandler KeyUp;
+
+        /// <summary>
+        ///     Occurs when a key is released. This includes additional event data such as if the event was injected.
+        /// </summary>
+        event EventHandler<KeyEventArgsExt> KeyUpExt;
     }
 }

--- a/MouseKeyHook/Implementation/EventFacade.cs
+++ b/MouseKeyHook/Implementation/EventFacade.cs
@@ -18,6 +18,12 @@ namespace Gma.System.MouseKeyHook.Implementation
             remove { GetKeyListener().KeyDown -= value; }
         }
 
+        public event EventHandler<KeyEventArgsExt> KeyDownExt
+        {
+            add { GetKeyListener().KeyDownExt += value; }
+            remove { GetKeyListener().KeyDownExt -= value; }
+        }
+
         public event KeyPressEventHandler KeyPress
         {
             add { GetKeyListener().KeyPress += value; }
@@ -36,7 +42,13 @@ namespace Gma.System.MouseKeyHook.Implementation
             remove { GetKeyListener().KeyUp -= value; }
         }
 
-	    public event MouseEventHandler MouseMove
+        public event EventHandler<KeyEventArgsExt> KeyUpExt
+        {
+            add { GetKeyListener().KeyUpExt += value; }
+            remove { GetKeyListener().KeyUpExt -= value; }
+        }
+
+        public event MouseEventHandler MouseMove
         {
             add { GetMouseListener().MouseMove += value; }
             remove { GetMouseListener().MouseMove -= value; }

--- a/MouseKeyHook/Implementation/KeyListener.cs
+++ b/MouseKeyHook/Implementation/KeyListener.cs
@@ -18,13 +18,29 @@ namespace Gma.System.MouseKeyHook.Implementation
         }
 
         public event KeyEventHandler KeyDown;
+        public event EventHandler<KeyEventArgsExt> KeyDownExt;
         public event KeyPressEventHandler KeyPress;
         public event EventHandler<KeyDownTxtEventArgs> KeyDownTxt;
         public event KeyEventHandler KeyUp;
+        public event EventHandler<KeyEventArgsExt> KeyUpExt;
 
         public void InvokeKeyDown(KeyEventArgsExt e)
         {
+            OnKeyDown(e);
+            OnKeyDownExt(e);
+        }
+
+        private void OnKeyDown(KeyEventArgsExt e)
+        {
             var handler = KeyDown;
+            if (handler == null || e.Handled || !e.IsKeyDown)
+                return;
+            handler(this, e);
+        }
+
+        private void OnKeyDownExt(KeyEventArgsExt e)
+        {
+            var handler = KeyDownExt;
             if (handler == null || e.Handled || !e.IsKeyDown)
                 return;
             handler(this, e);
@@ -48,7 +64,21 @@ namespace Gma.System.MouseKeyHook.Implementation
 
         public void InvokeKeyUp(KeyEventArgsExt e)
         {
+            OnKeyUp(e);
+            OnKeyUpExt(e);
+        }
+
+        private void OnKeyUp(KeyEventArgsExt e)
+        {
             var handler = KeyUp;
+            if (handler == null || e.Handled || !e.IsKeyUp)
+                return;
+            handler(this, e);
+        }
+
+        private void OnKeyUpExt(KeyEventArgsExt e)
+        {
+            var handler = KeyUpExt;
             if (handler == null || e.Handled || !e.IsKeyUp)
                 return;
             handler(this, e);

--- a/MouseKeyHook/Implementation/MouseListener.cs
+++ b/MouseKeyHook/Implementation/MouseListener.cs
@@ -207,7 +207,7 @@ namespace Gma.System.MouseKeyHook.Implementation
 
                 if (m_IsDragging)
                 {
-                    var dragArgs = new MouseEventExtArgs(e.Button, e.Clicks, m_DragStartPosition, e.Delta, e.Timestamp, e.IsMouseButtonDown, e.IsMouseButtonUp, e.IsHorizontalWheel);
+                    var dragArgs = new MouseEventExtArgs(e.Button, e.Clicks, m_DragStartPosition, e.Delta, e.Timestamp, e.IsMouseButtonDown, e.IsMouseButtonUp, e.IsHorizontalWheel, e.IsInjected);
                     OnDragStarted(dragArgs);
                     OnDragStartedExt(dragArgs);
                 }

--- a/MouseKeyHook/MouseKeyHook.csproj
+++ b/MouseKeyHook/MouseKeyHook.csproj
@@ -7,10 +7,10 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <AssemblyTitle>MouseKeyHook</AssemblyTitle>
     <AssemblyName>Gma.System.MouseKeyHook</AssemblyName>
-    <Version>5.7.1</Version>
+    <Version>5.8.0</Version>
     <DelaySign>false</DelaySign>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net7.0-windows;net6.0-windows;net472;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net7.0-windows;net6.0-windows;net472;net48</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>Gma.System.MouseKeyHook</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/MouseKeyHook/WinApi/MouseStruct.cs
+++ b/MouseKeyHook/WinApi/MouseStruct.cs
@@ -46,6 +46,11 @@ namespace Gma.System.MouseKeyHook.WinApi
         [FieldOffset(0x0A)] public short MouseData;
 
         /// <summary>
+        ///     Specifies the  event-injected flag.
+        /// </summary>
+        [FieldOffset(0x0C)] public uint Flags;
+
+        /// <summary>
         ///     Returns a Timestamp associated with the input, in System Ticks.
         /// </summary>
         [FieldOffset(0x10)] public int Timestamp;

--- a/examples/ConsoleHook.Rx/ConsoleHook.Rx.csproj
+++ b/examples/ConsoleHook.Rx/ConsoleHook.Rx.csproj
@@ -4,7 +4,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{F9B78F1A-F065-4BB4-A15B-393DFFE8DB0B}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0-windows;net6.0-windows;net472;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net7.0-windows;net6.0-windows;net472;net48</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>ConsoleHook.Rx</RootNamespace>
     <AssemblyName>ConsoleHook.Rx</AssemblyName>

--- a/examples/ConsoleHook/ConsoleHook.csproj
+++ b/examples/ConsoleHook/ConsoleHook.csproj
@@ -4,7 +4,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{490FBC6C-B347-4C33-B8EF-5C67C7C4C884}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0-windows;net6.0-windows;net472;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net7.0-windows;net6.0-windows;net472;net48</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>ConsoleHook</RootNamespace>
     <AssemblyName>ConsoleHook</AssemblyName>

--- a/examples/FormsExample/FormsExample.csproj
+++ b/examples/FormsExample/FormsExample.csproj
@@ -4,7 +4,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{693C8A54-2FA1-408B-9896-7CB1E5E9E257}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net7.0-windows;net6.0-windows;net472;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net7.0-windows;net6.0-windows;net472;net48</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Demo</RootNamespace>


### PR DESCRIPTION
I needed to be able to detect if a mouse or keyboard event was injected using one of the windows inject primitives, in my case SendInput, to only allow injected events and suppress events from the real keyboard and mouse.

So I added a new property in the KeyEventArgsExt and MouseEventExtArgs called IsInjected that is set to true of the event is injected and not a real event from the keyboard or mouse.

And I added new keyboard events with the extended keyboard arguments to make the new functionality more easily accessible and similar to how mouse events are handled. Things are a bit more consistent now.

I also updated the targets to include .net 8 and increased the version to 5.8 because it has some new features.

Would it be possible to make a new nuget release from these updates, to bump the nuget package to version 5.8?

I know this merge is just for the vnext branch, I think then it needs to be merged in the main branch and then a release needs to be made for the nuget package.